### PR TITLE
Add tournament bracket layout

### DIFF
--- a/app/Livewire/TournamentRounds.php
+++ b/app/Livewire/TournamentRounds.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use App\Services\TournamentRoundService;
+use App\Models\Tournament;
+use Livewire\Attributes\Layout;
+
+class TournamentRounds extends Component
+{
+    public Tournament $tournament;
+
+    public array $rounds = [];
+    public array $bracket = [];
+
+    public function mount(Tournament $tournament)
+    {
+        $this->tournament = $tournament;
+        $teamCount = $tournament->teams()->count();
+        $this->rounds = TournamentRoundService::generateRounds($teamCount);
+        $this->bracket = TournamentRoundService::generateBracketForTournament($tournament);
+    }
+
+    #[Layout('components.layouts.guest')]
+    public function render()
+    {
+        return view('livewire.tournament-rounds');
+    }
+}

--- a/app/Services/TournamentRoundService.php
+++ b/app/Services/TournamentRoundService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Services;
+
+class TournamentRoundService
+{
+    /**
+     * Generate round names for a single elimination tournament.
+     *
+     * @param int $maxTeams Number of teams in the first round.
+     * @return array<string>
+     */
+    public static function generateRounds(int $maxTeams): array
+    {
+        $rounds = [];
+        $teams = $maxTeams;
+
+        while ($teams >= 2) {
+            $rounds[] = self::roundName($teams);
+            $teams = intdiv($teams, 2);
+        }
+
+        return $rounds;
+    }
+
+    /**
+     * Convert a team count to a human readable round name.
+     */
+    protected static function roundName(int $teams): string
+    {
+        return match ($teams) {
+            2 => 'Finale',
+            4 => 'Halbfinale',
+            8 => 'Viertelfinale',
+            16 => 'Achtelfinale',
+            32 => 'Sechzehntelfinale',
+            64 => 'Zweiunddreißigstelfinale',
+            default => "Runde der {$teams}",
+        };
+    }
+
+    /**
+     * Build a tournament bracket using the registered teams and game results.
+     *
+     * @param \App\Models\Tournament $tournament
+     * @param int|null $seed Optional seed to get deterministic pairings.
+     * @return array<string, array<int, array{string, string}>>
+     */
+    public static function generateBracketForTournament(\App\Models\Tournament $tournament, ?int $seed = null): array
+    {
+        $teams = $tournament->teams()->pluck('name', 'id')->all();
+        $teamIds = array_keys($teams);
+
+        if ($seed !== null) {
+            mt_srand($seed);
+        }
+        shuffle($teamIds);
+        if ($seed !== null) {
+            mt_srand();
+        }
+
+        $bracket = [];
+        $currentTeamIds = $teamIds;
+
+        while (count(array_filter($currentTeamIds)) >= 2) {
+            $roundName = self::roundName(count(array_filter($currentTeamIds)));
+            $matches = [];
+            $nextRound = [];
+
+            for ($i = 0; $i < count($currentTeamIds); $i += 2) {
+                $team1Id = $currentTeamIds[$i] ?? null;
+                $team2Id = $currentTeamIds[$i + 1] ?? null;
+
+                $team1 = $team1Id ? ($teams[$team1Id] ?? 'TBD') : 'TBD';
+                $team2 = $team2Id ? ($teams[$team2Id] ?? 'TBD') : 'TBD';
+
+                $matches[] = [$team1, $team2];
+
+                $winnerId = null;
+                if ($team1Id && $team2Id) {
+                    $game = $tournament->games()
+                        ->whereIn('team1_id', [$team1Id, $team2Id])
+                        ->whereIn('team2_id', [$team1Id, $team2Id])
+                        ->first();
+
+                    if ($game && $game->status === 'completed') {
+                        $winnerId = $game->team1_score >= $game->team2_score ? $game->team1_id : $game->team2_id;
+                    }
+                }
+
+                $nextRound[] = $winnerId;
+            }
+
+            $bracket[$roundName] = $matches;
+            $currentTeamIds = $nextRound;
+        }
+
+        return $bracket;
+    }
+
+    /**
+     * Generate bracket pairings for a single elimination tournament.
+     * The bracket is returned as an associative array keyed by round name.
+     *
+     * @param array<int, string> $teams List of team names in the first round.
+     * @return array<string, array<int, array{string, string}>>
+     */
+    public static function generateBracket(array $teams): array
+    {
+        $bracket = [];
+        $currentTeams = $teams;
+
+        while (count($currentTeams) >= 2) {
+            $roundName = self::roundName(count($currentTeams));
+            $matches = [];
+
+            for ($i = 0; $i < count($currentTeams); $i += 2) {
+                $team1 = $currentTeams[$i] ?? 'TBD';
+                $team2 = $currentTeams[$i + 1] ?? 'TBD';
+                $matches[] = [$team1, $team2];
+            }
+
+            $bracket[$roundName] = $matches;
+            // Prepare next round placeholder team names
+            $currentTeams = [];
+            foreach ($matches as $index => $_match) {
+                $currentTeams[] = "Winner of {$roundName} Match " . ($index + 1);
+            }
+        }
+
+        return $bracket;
+    }
+}

--- a/resources/views/livewire/tournament-rounds.blade.php
+++ b/resources/views/livewire/tournament-rounds.blade.php
@@ -1,0 +1,16 @@
+<div class="overflow-x-auto p-4">
+    <div class="flex space-x-8">
+        @foreach($bracket as $roundName => $matches)
+            <div class="flex flex-col space-y-4">
+                <h3 class="text-center font-semibold text-gray-900 dark:text-white">{{ $roundName }}</h3>
+                @foreach($matches as [$team1, $team2])
+                    <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 w-48">
+                        <p class="text-center text-gray-700 dark:text-gray-200">{{ $team1 }}</p>
+                        <p class="text-center text-sm text-gray-500 dark:text-gray-400">vs</p>
+                        <p class="text-center text-gray-700 dark:text-gray-200">{{ $team2 }}</p>
+                    </div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Livewire\Tournaments\Show as TournamentShow;
 /* Tournaments Admin */
 use App\Livewire\Admin\Tournaments\Index as AdminTournamentsIndex;
 use App\Livewire\Admin\Tournaments\Show as AdminTournamentsShow;
+use App\Livewire\TournamentRounds;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', Landing::class)
@@ -38,3 +39,6 @@ Route::get('logout', function () {
     auth()->logout();
     return redirect()->route('landing');
 })->name('logout');
+
+Route::get('/tournaments/{tournament}/bracket', TournamentRounds::class)
+    ->name('tournaments.bracket');

--- a/tests/Unit/TournamentBracketFromTournamentTest.php
+++ b/tests/Unit/TournamentBracketFromTournamentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Tournament;
+use App\Models\Team;
+use App\Models\Game;
+use App\Services\TournamentRoundService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('generates bracket using tournament game results', function () {
+    $tournament = Tournament::create([
+        'name' => 'Test Cup',
+        'max_teams' => 4,
+    ]);
+
+    $teamA = $tournament->teams()->create(['name' => 'Alpha']);
+    $teamB = $tournament->teams()->create(['name' => 'Bravo']);
+    $teamC = $tournament->teams()->create(['name' => 'Charlie']);
+    $teamD = $tournament->teams()->create(['name' => 'Delta']);
+
+    $game1 = new Game();
+    $game1->team1_id = $teamD->id;
+    $game1->team2_id = $teamA->id;
+    $game1->status = 'completed';
+    $game1->team1_score = 16;
+    $game1->team2_score = 10;
+    $tournament->games()->save($game1);
+
+    $game2 = new Game();
+    $game2->team1_id = $teamC->id;
+    $game2->team2_id = $teamB->id;
+    $game2->status = 'completed';
+    $game2->team1_score = 8;
+    $game2->team2_score = 16;
+    $tournament->games()->save($game2);
+
+    $bracket = TournamentRoundService::generateBracketForTournament($tournament, 1);
+
+    expect(array_keys($bracket))->toEqual(['Halbfinale', 'Finale']);
+    expect($bracket['Halbfinale'])->toContain([$teamD->name, $teamA->name])
+        ->toContain([$teamC->name, $teamB->name]);
+    expect($bracket['Finale'][0])->toContain($teamD->name, $teamB->name);
+});

--- a/tests/Unit/TournamentRoundServiceTest.php
+++ b/tests/Unit/TournamentRoundServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Services\TournamentRoundService;
+
+it('generates correct round names', function () {
+    $rounds = TournamentRoundService::generateRounds(16);
+    expect($rounds)->toEqual([
+        'Achtelfinale',
+        'Viertelfinale',
+        'Halbfinale',
+        'Finale',
+    ]);
+});
+
+it('generates bracket pairings', function () {
+    $teams = ['Team 1', 'Team 2', 'Team 3', 'Team 4'];
+    $bracket = TournamentRoundService::generateBracket($teams);
+
+    expect(array_keys($bracket))->toEqual(['Halbfinale', 'Finale']);
+    expect($bracket['Halbfinale'])->toEqual([
+        ['Team 1', 'Team 2'],
+        ['Team 3', 'Team 4'],
+    ]);
+});


### PR DESCRIPTION
## Summary
- extend `TournamentRoundService` with `generateBracketForTournament` to compute matchups from a tournament and its game results
- update `TournamentRounds` component to display a tournament bracket
- expose the new bracket via `/tournaments/{tournament}/bracket`
- add unit test for the new bracket generation logic

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68590af64f8c8327bbcaf64c958337e3